### PR TITLE
Global Time Range as date_range basis

### DIFF
--- a/public/agg_types/comparing.html
+++ b/public/agg_types/comparing.html
@@ -30,7 +30,7 @@
           name="comparing"
           ng-model="agg.params.range.comparing"
           required
-          ng-options="offset as offset.display for offset in aggParam.comparingOffsets track by offset.offset"
+          ng-options="offset as offset.display for offset in aggParam.comparingOffsets track by offset.display"
           class="form-control">
         </select>
       </td>

--- a/public/agg_types/comparing.html
+++ b/public/agg_types/comparing.html
@@ -1,50 +1,26 @@
 <div ng-controller="aggParam.controller">
-  <table class="vis-editor-agg-editor-ranges form-group">
-    <tr>
-      <td>
-        <label id="visEditorDateRangeFrom{{agg.id}}">From</label>
-        <input
-          aria-labelledby="visEditorDateRangeFrom{{agg.id}}"
-          ng-model="agg.params.range.from"
-          validate-date-math
-          type="text"
-          class="form-control"
-          name="agg.params.range.from" />
-      </td>
-      <td>
-        <label id="visEditorDateRangeTo{{agg.id}}">To</label>
-        <input
-          aria-labelledby="visEditorDateRangeTo{{agg.id}}"
-          ng-model="agg.params.range.to"
-          validate-date-math
-          class="form-control"
-          name="agg.params.range.to" />
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <label for="visEditorDateRangeComparing{{agg.id}}">Comparing</label>
-        <select
-          id="visEditorDateRangeComparing{{agg.id}}"
-          name="comparing"
-          ng-model="agg.params.range.comparing"
-          required
-          ng-options="offset as offset.display for offset in aggParam.comparingOffsets track by offset.display"
-          class="form-control">
-        </select>
-      </td>
-      <td>
-        <label for="visEditorDateRangeFormat{{agg.id}}">Format</label>
-        <select
-          id="visEditorDateRangeFormat{{agg.id}}"
-          name="format"
-          ng-model="agg.params.range.format"
-          required
-          ng-options="format as format for format in aggParam.comparingFormats"
-          class="form-control">
-        </select>
-      </td>
-    </tr>
-  </table>
+  <div class="vis-editor-agg-form-row">
+    <div class="form-group">
+      <label for="visEditorDateRangeComparing{{agg.id}}">Comparing</label>
+      <select
+        id="visEditorDateRangeComparing{{agg.id}}"
+        name="comparing"
+        ng-model="agg.params.range.comparing"
+        required
+        ng-options="offset as offset.display for offset in aggParam.comparingOffsets track by offset.display"
+        class="form-control">
+      </select>
+    </div>
+    <div class="form-group">
+      <label for="visEditorDateRangeFormat{{agg.id}}">Format</label>
+      <select
+        id="visEditorDateRangeFormat{{agg.id}}"
+        name="format"
+        ng-model="agg.params.range.format"
+        required
+        ng-options="format as format for format in aggParam.comparingFormats"
+        class="form-control">
+      </select>
+    </div>
+  </div>
 </div>

--- a/public/agg_types/comparing.js
+++ b/public/agg_types/comparing.js
@@ -3,25 +3,25 @@ import moment from 'moment';
 import 'ui/directives/validate_date_math';
 import { AggTypesBucketsBucketAggTypeProvider } from 'ui/agg_types/buckets/_bucket_agg_type';
 import comparingAggTemplate from './comparing.html';
-import { comparingAggController }from './comparing_controller';
+import { comparingAggController } from './comparing_controller';
 
 const COMPARING_OFFSETS = [
   {
     display: 'None',
-    offset: { unit: 0, value: 'days' }
+    offset: { value: 0, unit: 'days' }
   },
   {
     display: 'Previous Day',
-    offset: { unit: 1, value: 'day' },
+    offset: { value: 1, unit: 'day' },
     default: true
   },
   {
     display: 'Previous Week',
-    offset: { unit: 7, value: 'days' }
+    offset: { value: 7, unit: 'days' }
   },
   {
     display: 'Previous Month',
-    offset: { unit: 1, value: 'month' }
+    offset: { value: 1, unit: 'month' }
   }
 ];
 
@@ -29,7 +29,7 @@ const COMPARING_FORMATS = [ '%', 'Absolute' ];
 
 function getDate(date, offset) {
   if (!offset) return date.toISOString();
-  return date.clone().subtract(offset.unit, offset.value).toISOString();
+  return date.clone().subtract(offset.value, offset.unit).toISOString();
 }
 
 export function AggTypesBucketsComparingProvider(config, Private) {

--- a/public/agg_types/comparing.js
+++ b/public/agg_types/comparing.js
@@ -54,8 +54,6 @@ export function AggTypesBucketsComparingProvider(config, Private) {
         comparingOffsets: COMPARING_OFFSETS,
         comparingFormats: COMPARING_FORMATS,
         default: {
-          from: 'now/d',
-          to: 'now',
           comparing: COMPARING_OFFSETS.find(offset => offset.default),
           format: '%'
         },

--- a/public/agg_types/comparing.js
+++ b/public/agg_types/comparing.js
@@ -81,8 +81,9 @@ export function AggTypesBucketsComparingProvider(config, Private) {
             }
           ];
 
-          // Sets date ranges
+          // Sets date ranges and date format
           output.params.ranges = ranges;
+          output.params.format = 'date_time';
 
           // Sets agg time_zone
           const isDefaultTimezone = config.isDefault('dateFormat:tz');

--- a/public/comparing_hack.js
+++ b/public/comparing_hack.js
@@ -7,6 +7,9 @@ import { decorateVis } from './decorators/vis';
 import { decorateAggConfigResult } from './decorators/agg_config_result';
 import './decorators/agg_table';
 import './decorators/paginated_table';
+import './decorators/visualize';
+import './request_handlers/comparing';
+import './response_handlers/comparing';
 import './styles/comparing.less';
 const appId = chrome.getApp().id;
 

--- a/public/comparing_hack.js
+++ b/public/comparing_hack.js
@@ -1,9 +1,10 @@
-import { uiModules } from  'ui/modules';
 import chrome from 'ui/chrome';
+import { uiModules } from  'ui/modules';
 import { decorateAggTypes } from './decorators/agg_types';
+import { decorateRootSearchSource } from './decorators/root_search_source';
 import { decorateTabbedAggResponseWriterProvider } from './decorators/response_writer';
-import { decorateAggConfigResult } from './decorators/agg_config_result';
 import { decorateVis } from './decorators/vis';
+import { decorateAggConfigResult } from './decorators/agg_config_result';
 import './decorators/agg_table';
 import './decorators/paginated_table';
 import './styles/comparing.less';
@@ -15,6 +16,7 @@ if (appId === 'kibana') {
     .get('comparable_time_range', ['kibana'])
     .run((Private) => {
       decorateAggTypes(Private);
+      decorateRootSearchSource(Private);
       decorateTabbedAggResponseWriterProvider(Private);
       decorateVis(Private);
       decorateAggConfigResult();

--- a/public/decorators/agg_table.js
+++ b/public/decorators/agg_table.js
@@ -39,7 +39,7 @@ if (appId === 'kibana') {
               const field = agg.getField();
               const isFieldDate = field && field.type === 'date';
               const isBucketColumn = agg.type.type === 'buckets';
-              if(isFieldDate || isBucketColumn) return formattedColumn;
+              if (isFieldDate || isBucketColumn) return formattedColumn;
 
               // Adds formatter into formattedColumn
               formattedColumn.formatter = agg.fieldFormatter('text');

--- a/public/decorators/root_search_source.js
+++ b/public/decorators/root_search_source.js
@@ -8,7 +8,7 @@ export function decorateRootSearchSource(Private) {
   rootSearchSource.filter(function (globalSource) {
     // Returns no time range if the request is using comparing
     const isUsingComparing = !!globalSource.get('filter').find(f => f.comparing);
-    if(isUsingComparing) return;
+    if (isUsingComparing) return;
 
     // Otherwise, gets global time range from rootSearchSource
     return filterFn.apply(this, arguments);

--- a/public/decorators/root_search_source.js
+++ b/public/decorators/root_search_source.js
@@ -1,0 +1,16 @@
+import { RootSearchSourceProvider } from 'ui/courier/data_source/_root_search_source';
+
+export function decorateRootSearchSource(Private) {
+  const rootSearchSource = Private(RootSearchSourceProvider).getGlobalSource();
+
+  // Keeps filter original function into a variable
+  const filterFn = rootSearchSource.get('filter');
+  rootSearchSource.filter(function (globalSource) {
+    // Returns no time range if the request is using comparing
+    const isUsingComparing = !!globalSource.get('filter').find(f => f.comparing);
+    if(isUsingComparing) return;
+
+    // Otherwise, gets global time range from rootSearchSource
+    return filterFn.apply(this, arguments);
+  });
+}

--- a/public/decorators/vis.js
+++ b/public/decorators/vis.js
@@ -1,5 +1,6 @@
 import { VisTypesRegistryProvider } from 'ui/registry/vis_types';
 import { VisSchemasProvider } from 'ui/vis/editors/default/schemas';
+import { ComparingRequestHandlerProvider } from '../request_handlers/comparing';
 import { ComparingResponseHandlerProvider } from '../response_handlers/comparing';
 
 const ALLOWED_VIS_TYPES = ['table'];
@@ -38,6 +39,7 @@ function getAggFilter(aggFilter) {
 export function decorateVis(Private) {
   const VisTypes = Private(VisTypesRegistryProvider);
   const Schemas = Private(VisSchemasProvider);
+  const requestHandler = Private(ComparingRequestHandlerProvider).handler;
   const responseHandler = Private(ComparingResponseHandlerProvider).handler;
 
   VisTypes.forEach(vis => {
@@ -67,7 +69,8 @@ export function decorateVis(Private) {
         });
         vis.editorConfig.schemas = new Schemas(schemas);
 
-        // Modify the default responseHandler of the vis
+        // Modify the default requestHandler and responseHandler of the vis
+        vis.requestHandler = requestHandler;
         vis.responseHandler = responseHandler;
       }
     }

--- a/public/decorators/vis.js
+++ b/public/decorators/vis.js
@@ -1,7 +1,5 @@
 import { VisTypesRegistryProvider } from 'ui/registry/vis_types';
 import { VisSchemasProvider } from 'ui/vis/editors/default/schemas';
-import { ComparingRequestHandlerProvider } from '../request_handlers/comparing';
-import { ComparingResponseHandlerProvider } from '../response_handlers/comparing';
 
 const ALLOWED_VIS_TYPES = ['table'];
 
@@ -39,8 +37,6 @@ function getAggFilter(aggFilter) {
 export function decorateVis(Private) {
   const VisTypes = Private(VisTypesRegistryProvider);
   const Schemas = Private(VisSchemasProvider);
-  const requestHandler = Private(ComparingRequestHandlerProvider).handler;
-  const responseHandler = Private(ComparingResponseHandlerProvider).handler;
 
   VisTypes.forEach(vis => {
     if (vis.editorConfig && vis.editorConfig.schemas) {
@@ -69,9 +65,11 @@ export function decorateVis(Private) {
         });
         vis.editorConfig.schemas = new Schemas(schemas);
 
-        // Modify the default requestHandler and responseHandler of the vis
-        vis.requestHandler = requestHandler;
-        vis.responseHandler = responseHandler;
+        // Modifies the default request and response handlers of the vis.
+        //  It will look for a 'comparing' type in registered lists
+        //  of both request and response handlers
+        vis.requestHandler = 'comparing';
+        vis.responseHandler = 'comparing';
       }
     }
   });

--- a/public/decorators/visualize.js
+++ b/public/decorators/visualize.js
@@ -1,0 +1,31 @@
+import chrome from 'ui/chrome';
+import { uiModules } from 'ui/modules';
+const appId = chrome.getApp().id;
+
+// Only inject decorator on kibana app
+if (appId === 'kibana') {
+  uiModules
+    .get('kibana/directive')
+    .config($provide => {
+      $provide.decorator('visualizeDirective', $delegate => {
+        const directive = $delegate[0];
+        const link = directive.link;
+
+        directive.compile = () => {
+          return function ($scope) {
+            link.apply(this, arguments);
+
+            // Overrides shouldShowSpyPanel function
+            const shouldShowSpyPanel = $scope.shouldShowSpyPanel;
+            $scope.shouldShowSpyPanel = () => {
+              const isUsingComparing = $scope.vis.type.requestHandler === 'comparing';
+              if(isUsingComparing && $scope.vis.type.requiresSearch && $scope.showSpyPanel) return true;
+              return shouldShowSpyPanel();
+            };
+          };
+        };
+
+        return $delegate;
+      });
+    });
+}

--- a/public/decorators/visualize.js
+++ b/public/decorators/visualize.js
@@ -19,7 +19,7 @@ if (appId === 'kibana') {
             const shouldShowSpyPanel = $scope.shouldShowSpyPanel;
             $scope.shouldShowSpyPanel = () => {
               const isUsingComparing = $scope.vis.type.requestHandler === 'comparing';
-              if(isUsingComparing && $scope.vis.type.requiresSearch && $scope.showSpyPanel) return true;
+              if (isUsingComparing && $scope.vis.type.requiresSearch && $scope.showSpyPanel) return true;
               return shouldShowSpyPanel();
             };
           };

--- a/public/lib/comparing.js
+++ b/public/lib/comparing.js
@@ -36,7 +36,7 @@ export function ComparingProvider(Private) {
 
   return function getDifference(n1, n2, isPercentage) {
     const isInvalidDiff = isPercentage && !n1;
-    if(isInvalidDiff) return INVALID_DIFF_TEXT;
+    if (isInvalidDiff) return INVALID_DIFF_TEXT;
 
     const diffFn = isPercentage ? findDifferencePct : findDifferenceAbs;
     const diff = diffFn(n1, n2);

--- a/public/request_handlers/comparing.js
+++ b/public/request_handlers/comparing.js
@@ -14,12 +14,6 @@ const ComparingRequestHandlerProvider = function (Private, courier, timefilter) 
    */
   function handleComparing(vis, searchSource) {
     const isUsingComparing = !!vis.aggs.byTypeName.comparing;
-
-    // Disables global time range filter if the query is using comparing agg.
-    //  Also needed to enable it again for future requests
-    searchSource.skipTimeRangeFilter = isUsingComparing;
-
-    // Stop executing function if comparing agg is missing
     if (!isUsingComparing) return;
 
     // Gets requestedDateRange from comparing agg
@@ -32,9 +26,10 @@ const ComparingRequestHandlerProvider = function (Private, courier, timefilter) 
     };
 
     // Creates a new time range filter
+    //  `comparing` field will be used in RootSearchSource.filter decorator
     const currentFilter = [ ...searchSource.get('filter') ];
     currentFilter.push({
-      comparing: true, // This will be used later to filter this query out
+      comparing: true,
       query: {
         range: {
           [timeField]: {

--- a/public/request_handlers/comparing.js
+++ b/public/request_handlers/comparing.js
@@ -22,27 +22,27 @@ const ComparingRequestHandlerProvider = function (Private, courier, timefilter) 
     // Stop executing function if comparing agg is missing
     if (!isUsingComparing) return;
 
-    // Creates a new time range filter
+    // Gets requestedDateRange from comparing agg
     const comparingAgg = vis.aggs.byTypeName.comparing[0];
-
     const aggDateRanges = comparingAgg.toDsl().date_range.ranges;
     const requestedDateRange = {
       from: dateMath.parse(aggDateRanges[0].from),
       to: dateMath.parse(aggDateRanges[1].to)
     };
 
-    const timeRangeFilter = {
-      language: 'lucene',
+    // Creates a new time range filter
+    const currentFilter = [ ...searchSource.get('filter') ];
+    currentFilter.push({
       query: {
         range: {
-          '@timestamp': {
+          '@timestamp': { //TODO: replace @timestamp?
             gte: moment(requestedDateRange.from).toISOString(),
             lte: moment(requestedDateRange.to).toISOString()
           }
         }
       }
-    };
-    searchSource.set('query', timeRangeFilter);
+    });
+    searchSource.set('filter', currentFilter);
   }
 
   return {

--- a/public/request_handlers/comparing.js
+++ b/public/request_handlers/comparing.js
@@ -1,0 +1,19 @@
+import { VisRequestHandlersRegistryProvider } from 'ui/registry/vis_request_handlers';
+import { CourierRequestHandlerProvider } from 'ui/vis/request_handlers/courier';
+
+const ComparingRequestHandlerProvider = function (Private, courier, timefilter) {
+  const courierRequestHandler = Private(CourierRequestHandlerProvider);
+
+  return {
+    name: 'comparing',
+    handler: function (vis, appState, uiState, queryFilter, searchSource) {
+
+      console.log('comparing reqHandler decorator');
+      return courierRequestHandler.handler(...arguments);
+    }
+  };
+};
+
+VisRequestHandlersRegistryProvider.register(ComparingRequestHandlerProvider);
+
+export { ComparingRequestHandlerProvider };

--- a/public/request_handlers/comparing.js
+++ b/public/request_handlers/comparing.js
@@ -23,8 +23,9 @@ const ComparingRequestHandlerProvider = function (Private, courier, timefilter) 
     if (!isUsingComparing) return;
 
     // Gets requestedDateRange from comparing agg
-    const comparingAgg = vis.aggs.byTypeName.comparing[0];
-    const aggDateRanges = comparingAgg.toDsl().date_range.ranges;
+    const comparingAgg = vis.aggs.byTypeName.comparing[0].toDsl();
+    const timeField = comparingAgg.date_range.field;
+    const aggDateRanges = comparingAgg.date_range.ranges;
     const requestedDateRange = {
       from: dateMath.parse(aggDateRanges[0].from),
       to: dateMath.parse(aggDateRanges[1].to)
@@ -35,7 +36,7 @@ const ComparingRequestHandlerProvider = function (Private, courier, timefilter) 
     currentFilter.push({
       query: {
         range: {
-          '@timestamp': { //TODO: replace @timestamp?
+          [timeField]: {
             gte: moment(requestedDateRange.from).toISOString(),
             lte: moment(requestedDateRange.to).toISOString()
           }

--- a/public/request_handlers/comparing.js
+++ b/public/request_handlers/comparing.js
@@ -34,7 +34,8 @@ const ComparingRequestHandlerProvider = function (Private, courier, timefilter) 
         range: {
           [timeField]: {
             gte: moment(requestedDateRange.from).toISOString(),
-            lte: moment(requestedDateRange.to).toISOString()
+            lte: moment(requestedDateRange.to).toISOString(),
+            format: 'date_time'
           }
         }
       }

--- a/public/response_handlers/comparing.js
+++ b/public/response_handlers/comparing.js
@@ -9,7 +9,7 @@ function ComparingResponseHandlerProvider(Private) {
 
   function getBucketValues(buckets, aggId) {
     // If aggId is missing, returns doc_count values
-    if(!aggId) {
+    if (!aggId) {
       return {
         comparing: buckets[0].doc_count,
         actual: buckets[1].doc_count


### PR DESCRIPTION
This will allow users to compare data without changing the global time range. 

Main changes:
- Removing **From** and **To** fields from aggregation parameters
- Setting Kibana's global time range as first range of `date_range`
- Overriding Kibana's **global time range** in order to include **comparing** range