### PR TITLE
date_histogram aggregation handler

### DIFF
--- a/public/agg_types/comparing_controller.js
+++ b/public/agg_types/comparing_controller.js
@@ -50,22 +50,22 @@ export function comparingAggController($scope) {
     // Checks if comparing is last bucket
     const comparingBucket = getAggByType('comparing')[0];
     const lastBucket = _.findLast($scope.vis.getAggConfig(), agg => agg.schema.group === 'buckets');
-    const isComparingLastBucket = comparingBucket && lastBucket && lastBucket.id === comparingBucket.id;
-    if (!isComparingLastBucket) errorMessage = VALIDATION_ERROR_MESSAGES.LAST_BUCKET;
+    const isComparingOrderValid = comparingBucket && lastBucket && lastBucket.id === comparingBucket.id;
+    if (!isComparingOrderValid) errorMessage = VALIDATION_ERROR_MESSAGES.LAST_BUCKET;
 
     // Checks if date_histogram is first bucket
     const dateHistogramBuckets = getAggByType('date_histogram');
     const dateHistogramBucket = dateHistogramBuckets[0];
     const firstBucket = $scope.vis.getAggConfig().find(agg => agg.schema.group === 'buckets');
-    const isDateHistogramFirstBucket = dateHistogramBucket && firstBucket && firstBucket.id === dateHistogramBucket.id;
-    if (!isDateHistogramFirstBucket) errorMessage = VALIDATION_ERROR_MESSAGES.DATE_HISTOGRAM_FIRST;
+    const isDateHistogramOrderValid = dateHistogramBucket ? firstBucket && firstBucket.id === dateHistogramBucket.id : true;
+    if (!isDateHistogramOrderValid) errorMessage = VALIDATION_ERROR_MESSAGES.DATE_HISTOGRAM_FIRST;
 
     // Checks if only one date_histogram is used
     const maxOneDateHistogram = dateHistogramBuckets && dateHistogramBuckets.length <= 1;
-    const isDateHistogramValid = dateHistogramBuckets ? maxOneDateHistogram : true;
-    if (!isDateHistogramValid) errorMessage = VALIDATION_ERROR_MESSAGES.MAX_DATE_HISTOGRAM;
+    const isDateHistogramCountValid = dateHistogramBuckets ? maxOneDateHistogram : true;
+    if (!isDateHistogramCountValid) errorMessage = VALIDATION_ERROR_MESSAGES.MAX_DATE_HISTOGRAM;
 
-    const canUseAggregation = isComparingLastBucket && isDateHistogramFirstBucket && isDateHistogramValid;
+    const canUseAggregation = isComparingOrderValid && isDateHistogramOrderValid && isDateHistogramCountValid;
 
     // Removes error from comparing bucket
     if (comparingBucket.error) delete comparingBucket.error;

--- a/public/decorators/agg_table.js
+++ b/public/decorators/agg_table.js
@@ -24,7 +24,7 @@ if (appId === 'kibana') {
             // Validations
             if (!table) return;
             const hasColumns = !!table.columns.length;
-            const isUsingComparing = table.rows[0] && !!table.rows[0].find(col => col.comparing);
+            const isUsingComparing = table.rows[0] && !!table.rows[0].find(col => col.hasOwnProperty('comparing'));
             const shouldApplyComparing = hasColumns && isUsingComparing;
             if (!shouldApplyComparing) return;
 

--- a/public/response_handlers/comparing.js
+++ b/public/response_handlers/comparing.js
@@ -125,12 +125,10 @@ function ComparingResponseHandlerProvider(Private) {
   function handleDateHistogramResponse(vis, response, comparingAgg) {
     if (!vis.aggs.byTypeName.date_histogram) return response;
 
-    // TODO: handle custom
     const comparingAggId = comparingAgg.id;
     const comparingOffset = getOffset(vis.API.timeFilter, comparingAgg.params.range);
 
     // Considering there's only one date_histogram agg
-    //  TODO: Limit query to have only one date_histogram
     const dateHistogramAgg = vis.aggs.byTypeName.date_histogram[0];
 
     // TODO: implement a recursive function that finds nested date_histogram aggregations

--- a/public/response_handlers/comparing.js
+++ b/public/response_handlers/comparing.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'; // TODO: refactor lodash dependencies
-import moment from 'moment';
-import dateMath from '@elastic/datemath';
 import { AggResponseTabifyComparingProvider } from './tabify_comparing';
 import { VisResponseHandlersRegistryProvider } from 'ui/registry/vis_response_handlers';
 import { ComparingProvider } from '../lib/comparing';
+import { handleDateHistogramResponse } from './lib/date_histogram_handler';
+import { containsAgg } from './lib/utils';
 
 function ComparingResponseHandlerProvider(Private) {
   const tabifyComparing = Private(AggResponseTabifyComparingProvider);
@@ -21,39 +21,6 @@ function ComparingResponseHandlerProvider(Private) {
     return {
       comparing: buckets[0][aggId].value,
       actual: buckets[1][aggId].value
-    };
-  }
-
-  function containsAgg(obj, aggId) {
-    return Object.keys(obj).includes(aggId);
-  }
-
-  function getDate(date, offset) {
-    const momentDate = moment(date);
-    if (!offset) return momentDate;
-    return momentDate.clone().subtract(offset.value, offset.unit);
-  }
-
-  /**
-   * Creates a diff object ({value, unit}) for custom comparing time ranges
-   *
-   * @param {*} comparingRange
-   * @param {*} timeFilter
-   */
-  function getOffset(timeFilter, comparingRange) {
-    // If it's not using custom comparing, returns selected offset
-    const isCustom = comparingRange.comparing.display === 'Custom';
-    if (!isCustom) return comparingRange.comparing.offset;
-
-    // Gets `from` dates of both current date and comparing date
-    const currentDateFrom = timeFilter.getBounds().min;
-    const comparingFrom = dateMath.parse(comparingRange.custom.from);
-
-    // Gets diff in milliseconds
-    const diff = currentDateFrom.diff(comparingFrom);
-    return {
-      value: diff,
-      unit: 'milliseconds'
     };
   }
 
@@ -120,92 +87,6 @@ function ComparingResponseHandlerProvider(Private) {
         }
       };
     }
-  }
-
-  /**
-   * Builds comparing aggregation for responses containing date_histogram aggregations.
-   * Looks for `comparingAggId` recursively and returns a "comparing agg bucket"
-   *  using information from both `bucket` and `comparingBucket`
-   *
-   * @param {*} bucket
-   * @param {*} comparingBucket
-   * @param {*} comparingAggId
-   */
-  function getComparingFromDateHistogram(bucket, comparingBucket, comparingAggId) {
-    if (containsAgg(bucket, comparingAggId)) {
-      // If comparingBucket is missing, it means that there's no bucket
-      //  value in comparing range, so just returns bucket itself
-      if (!comparingBucket) return bucket;
-
-      // Builds new comparing agg bucket based on comparing date range
-      //  from comparingBucket and base date range from bucket
-      const newComparingBuckets = [
-        comparingBucket[comparingAggId].buckets[0],
-        bucket[comparingAggId].buckets[1]
-      ];
-
-      return {
-        ...bucket,
-        [comparingAggId]: {
-          ...bucket[comparingAggId],
-          buckets: newComparingBuckets
-        }
-      };
-    } else {
-      // Finds next agg child (looks for buckets array inside every child)
-      const nextAggId = Object.keys(bucket).find(k => !!bucket[k].buckets);
-      const newBuckets = bucket[nextAggId].buckets.map(subBucket => {
-        const comparingSubBucket = comparingBucket && comparingBucket[nextAggId].buckets.find(b => b.key === subBucket.key);
-        return getComparingFromDateHistogram(subBucket, comparingSubBucket, comparingAggId);
-      });
-      return {
-        ...bucket,
-        [nextAggId]: {
-          ...bucket[nextAggId],
-          buckets: newBuckets
-        }
-      };
-    }
-  }
-
-  function handleDateHistogramResponse(vis, response, comparingAgg) {
-    if (!vis.aggs.byTypeName.date_histogram) return response;
-
-    const comparingAggId = comparingAgg.id;
-    const comparingOffset = getOffset(vis.API.timeFilter, comparingAgg.params.range);
-    const currentDateFilter = vis.API.timeFilter.getBounds();
-
-    // Considering there's only one date_histogram agg
-    const dateHistogramAgg = vis.aggs.byTypeName.date_histogram[0];
-
-    // This case will only work if date_histogram is the first one
-    //  TODO: implement a UI warning to make sure date_histogram is the first one when using comparing
-    const dateHistogramBuckets = response.aggregations[dateHistogramAgg.id].buckets;
-
-    // Extract the comparing values from sibbling buckets
-    const bucketsWithComparing = dateHistogramBuckets.map(bucket => {
-      // Gets comparing date to look for in sibbling buckets
-      const comparingBucketDate = getDate(bucket.key, comparingOffset);
-
-      // Finds comparingBucket using comparing date
-      const comparingBucket = dateHistogramBuckets.find(b => b.key === comparingBucketDate.valueOf());
-
-      return getComparingFromDateHistogram(bucket, comparingBucket, comparingAggId);
-    })
-      // Filters out unwanted out-of-bounds buckets.
-      //  This step is necessary since ES response contains both current and comparing range buckets
-      .filter(bucket => !!getDate(bucket.key).isBetween(currentDateFilter.min, currentDateFilter.max));
-
-    return {
-      ...response,
-      aggregations: {
-        ...response.aggregations,
-        [dateHistogramAgg.id]: {
-          ...response.aggregations[dateHistogramAgg.id],
-          buckets: bucketsWithComparing
-        }
-      }
-    };
   }
 
   function handleComparingResponse(vis, response) {

--- a/public/response_handlers/lib/date_histogram_handler.js
+++ b/public/response_handlers/lib/date_histogram_handler.js
@@ -1,0 +1,132 @@
+import moment from 'moment';
+import dateMath from '@elastic/datemath';
+import { containsAgg } from './utils';
+
+function getDate(date, offset) {
+  const momentDate = moment(date);
+  if (!offset) return momentDate;
+  return momentDate.clone().subtract(offset.value, offset.unit);
+}
+
+/**
+ * Creates a diff object ({value, unit}) for custom comparing time ranges
+ *
+ * @param {*} comparingRange
+ * @param {*} timeFilter
+ */
+function getOffset(timeFilter, comparingRange) {
+  // If it's not using custom comparing, returns selected offset
+  const isCustom = comparingRange.comparing.display === 'Custom';
+  if (!isCustom) return comparingRange.comparing.offset;
+
+  // Gets `from` dates of both current date and comparing date
+  const currentDateFrom = timeFilter.getBounds().min;
+  const comparingFrom = dateMath.parse(comparingRange.custom.from);
+
+  // Gets diff in milliseconds
+  const diff = currentDateFrom.diff(comparingFrom);
+  return {
+    value: diff,
+    unit: 'milliseconds'
+  };
+}
+
+/**
+ * Builds comparing aggregation for responses containing date_histogram aggregations.
+ * Looks for `comparingAggId` recursively and returns a "comparing agg bucket"
+ *  using information from both `bucket` and `comparingBucket`
+ *
+ * @param {*} bucket
+ * @param {*} comparingBucket
+ * @param {*} comparingAggId
+ */
+function getComparingFromDateHistogram(bucket, comparingBucket, comparingAggId) {
+  if (containsAgg(bucket, comparingAggId)) {
+    // If comparingBucket is missing, it means that there's no bucket
+    //  value in comparing range, so just returns bucket itself
+    if (!comparingBucket) return bucket;
+
+    // Builds new comparing agg bucket based on comparing date range
+    //  from comparingBucket and base date range from bucket
+    const newComparingBuckets = [
+      comparingBucket[comparingAggId].buckets[0],
+      bucket[comparingAggId].buckets[1]
+    ];
+
+    return {
+      ...bucket,
+      [comparingAggId]: {
+        ...bucket[comparingAggId],
+        buckets: newComparingBuckets
+      }
+    };
+  } else {
+    // Finds next agg child (looks for buckets array inside every child)
+    const nextAggId = Object.keys(bucket).find(k => !!bucket[k].buckets);
+    const newBuckets = bucket[nextAggId].buckets.map(subBucket => {
+      const comparingSubBucket = comparingBucket && comparingBucket[nextAggId].buckets.find(b => b.key === subBucket.key);
+      return getComparingFromDateHistogram(subBucket, comparingSubBucket, comparingAggId);
+    });
+    return {
+      ...bucket,
+      [nextAggId]: {
+        ...bucket[nextAggId],
+        buckets: newBuckets
+      }
+    };
+  }
+}
+
+/**
+ * Handles date_histogram in response.aggregations
+ *
+ * @param {*} vis
+ * @param {*} response
+ * @param {*} comparingAgg
+ */
+function handleDateHistogramResponse(vis, response, comparingAgg) {
+  if (!vis.aggs.byTypeName.date_histogram) return response;
+
+  const comparingAggId = comparingAgg.id;
+  const comparingOffset = getOffset(vis.API.timeFilter, comparingAgg.params.range);
+  const currentDateFilter = vis.API.timeFilter.getBounds();
+
+  // Considering there's only one date_histogram agg
+  const dateHistogramAgg = vis.aggs.byTypeName.date_histogram[0];
+
+  // This case will only work if date_histogram is the first one
+  //  TODO: implement a UI warning to make sure date_histogram is the first one when using comparing
+  const dateHistogramBuckets = response.aggregations[dateHistogramAgg.id].buckets;
+
+  // Extract the comparing values from sibbling buckets
+  const bucketsWithComparing = dateHistogramBuckets.map(bucket => {
+    // Gets comparing date to look for in sibbling buckets
+    const comparingBucketDate = getDate(bucket.key, comparingOffset);
+
+    // Finds comparingBucket using comparing date
+    const comparingBucket = dateHistogramBuckets.find(b => b.key === comparingBucketDate.valueOf());
+
+    return getComparingFromDateHistogram(bucket, comparingBucket, comparingAggId);
+  })
+    // Filters out unwanted out-of-bounds buckets.
+    //  This step is necessary since ES response contains both current and comparing range buckets
+    .filter(bucket => !!getDate(bucket.key).isBetween(currentDateFilter.min, currentDateFilter.max));
+
+  return {
+    ...response,
+    aggregations: {
+      ...response.aggregations,
+      [dateHistogramAgg.id]: {
+        ...response.aggregations[dateHistogramAgg.id],
+        buckets: bucketsWithComparing
+      }
+    }
+  };
+}
+
+export {
+  getDate,
+  getOffset,
+  getComparingFromDateHistogram,
+  handleDateHistogramResponse
+};

--- a/public/response_handlers/lib/date_histogram_handler.js
+++ b/public/response_handlers/lib/date_histogram_handler.js
@@ -94,8 +94,7 @@ function handleDateHistogramResponse(vis, response, comparingAgg) {
   // Considering there's only one date_histogram agg
   const dateHistogramAgg = vis.aggs.byTypeName.date_histogram[0];
 
-  // This case will only work if date_histogram is the first one
-  //  TODO: implement a UI warning to make sure date_histogram is the first one when using comparing
+  // Considering date_histogram is the first bucket agg
   const dateHistogramBuckets = response.aggregations[dateHistogramAgg.id].buckets;
 
   // Extract the comparing values from sibbling buckets

--- a/public/response_handlers/lib/utils.js
+++ b/public/response_handlers/lib/utils.js
@@ -1,0 +1,5 @@
+function containsAgg(obj, aggId) {
+  return Object.keys(obj).includes(aggId);
+}
+
+export { containsAgg };


### PR DESCRIPTION
This fixes the usage of `comparing` plugin with `date_histogram` aggregations.

Changes:
- [x] `date_histogram` handler created
- [x] Query error added when more than one `date_histogram` aggregation is used
- [x] `date_histogram` + other buckets aggregation handler created
- [x] Global time filter range changed to fetch specific dates (instead of whole period of comparing until current)