### PR TITLE
Hierarchical vis support (metrics for every bucket/level)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,3 +7,6 @@ settings:
       rootPackageName: 'comparable_time_range'
 globals:
   angular: false
+
+rules:
+  keyword-spacing: error

--- a/public/comparing_hack.js
+++ b/public/comparing_hack.js
@@ -4,6 +4,7 @@ import { decorateAggTypes } from './decorators/agg_types';
 import { decorateRootSearchSource } from './decorators/root_search_source';
 import { decorateTabbedAggResponseWriterProvider } from './decorators/response_writer';
 import { decorateVis } from './decorators/vis';
+import { decorateAggConfigs } from './decorators/agg_configs';
 import { decorateAggConfigResult } from './decorators/agg_config_result';
 import './decorators/agg_table';
 import './decorators/paginated_table';
@@ -22,6 +23,7 @@ if (appId === 'kibana') {
       decorateRootSearchSource(Private);
       decorateTabbedAggResponseWriterProvider(Private);
       decorateVis(Private);
+      decorateAggConfigs(Private);
       decorateAggConfigResult();
     });
 }

--- a/public/decorators/agg_configs.js
+++ b/public/decorators/agg_configs.js
@@ -1,0 +1,78 @@
+import _ from 'lodash'; // TODO: refactor lodash dependencies
+import * as prov from 'ui/vis/agg_configs';
+
+export function decorateAggConfigs(Private) {
+  // eslint-disable-next-line import/namespace
+  const AggConfigs = prov.AggConfigs || Private(prov.VisAggConfigsProvider);
+
+  /**
+   * Recursively removes undefined values from object.
+   * @param {*} obj
+   */
+  function removeEmptyValues(obj) {
+    return Object.keys(obj)
+      .filter(k => obj[k] != null) // Filters out undefined and null objects
+      .reduce((newObj, k) => {
+        // Recursive call for arrays
+        if (Array.isArray(obj[k])) return { ...newObj, [k]: obj[k].map(removeEmptyValues) };
+        // Recursive call for objects
+        return typeof obj[k] === 'object' ?
+          { ...newObj, [k]: removeEmptyValues(obj[k]) } :
+          { ...newObj, [k]: obj[k] };
+      }, {});
+  }
+
+  /**
+   * Applies comparing agg dsl for every bucket level recursively.
+   * @param {*} dsl
+   * @param {*} comparingAgg
+   * @param {*} nestedMetrics
+   */
+  function applyComparingDsl(dsl, comparingAgg, nestedMetrics) {
+    return Object.keys(dsl).reduce((obj, key) => {
+      const currentDsl = _.cloneDeep(dsl[key]);
+      const isLastBucket = currentDsl.aggs && !Object.keys(currentDsl.aggs).find(k => currentDsl.aggs[k].aggs);
+      // If currentDsl has aggreagations, applies comparing dsl
+      //  (last buckets don't accept sub-aggs)
+      if(currentDsl.aggs && !isLastBucket) {
+        // Calls itself recusrively for child aggs
+        currentDsl.aggs = applyComparingDsl(currentDsl.aggs, comparingAgg, nestedMetrics);
+        // Adds comparingAgg dsl + nestedMetrics dsls
+        currentDsl.aggs[comparingAgg.id] = {
+          ...comparingAgg.toDsl(),
+          aggs: nestedMetrics.reduce((obj, curr) => {
+            obj[curr.config.id] = curr.dsl;
+            return obj;
+          }, {})
+        };
+      }
+      obj[key] = currentDsl;
+      return obj;
+    }, {});
+  }
+
+  function handleHierarchicalVisComparing(dsl, vis) {
+    // Returns default dsl if vis isn't hierarchical
+    const isUsingComparing = !!vis.aggs.byTypeName.comparing;
+    if(!isUsingComparing || isUsingComparing && !vis.isHierarchical()) return dsl;
+
+    const comparingAgg = vis.aggs.byTypeName.comparing[0];
+
+    // Collect metrics to apply in comparing dsl
+    const nestedMetrics = vis.aggs.bySchemaGroup.metrics
+      .filter(agg => (agg.type.name !== 'count' && !agg.type.hasNoDsl))
+      .map(agg => ({ config: agg, dsl: agg.toDsl() }));
+
+    // Removes empty values from `toDsl` response
+    const filteredDsl = removeEmptyValues(dsl);
+
+    // Injects comparing agg dsl in dsl object
+    return applyComparingDsl(filteredDsl, comparingAgg, nestedMetrics);
+  }
+
+  const toDslFn = AggConfigs.prototype.toDsl;
+  AggConfigs.prototype.toDsl = function () {
+    const dsl = toDslFn.apply(this, arguments);
+    return handleHierarchicalVisComparing(dsl, this.vis);
+  };
+}

--- a/public/decorators/agg_configs.js
+++ b/public/decorators/agg_configs.js
@@ -34,7 +34,7 @@ export function decorateAggConfigs(Private) {
       const isLastBucket = currentDsl.aggs && !Object.keys(currentDsl.aggs).find(k => currentDsl.aggs[k].aggs);
       // If currentDsl has aggreagations, applies comparing dsl
       //  (last buckets don't accept sub-aggs)
-      if(currentDsl.aggs && !isLastBucket) {
+      if (currentDsl.aggs && !isLastBucket) {
         // Calls itself recusrively for child aggs
         currentDsl.aggs = applyComparingDsl(currentDsl.aggs, comparingAgg, nestedMetrics);
         // Adds comparingAgg dsl + nestedMetrics dsls
@@ -54,7 +54,7 @@ export function decorateAggConfigs(Private) {
   function handleHierarchicalVisComparing(dsl, vis) {
     // Returns default dsl if vis isn't hierarchical
     const isUsingComparing = !!vis.aggs.byTypeName.comparing;
-    if(!isUsingComparing || isUsingComparing && !vis.isHierarchical()) return dsl;
+    if (!isUsingComparing || isUsingComparing && !vis.isHierarchical()) return dsl;
 
     const comparingAgg = vis.aggs.byTypeName.comparing[0];
 

--- a/public/decorators/agg_configs.js
+++ b/public/decorators/agg_configs.js
@@ -35,7 +35,7 @@ export function decorateAggConfigs(Private) {
       // If currentDsl has aggreagations, applies comparing dsl
       //  (last buckets don't accept sub-aggs)
       if (currentDsl.aggs && !isLastBucket) {
-        // Calls itself recusrively for child aggs
+        // Calls itself recursively for child aggs
         currentDsl.aggs = applyComparingDsl(currentDsl.aggs, comparingAgg, nestedMetrics);
         // Adds comparingAgg dsl + nestedMetrics dsls
         currentDsl.aggs[comparingAgg.id] = {

--- a/public/response_handlers/comparing.js
+++ b/public/response_handlers/comparing.js
@@ -79,7 +79,7 @@ function ComparingResponseHandlerProvider(Private) {
     // Finds next agg child (looks for buckets array inside every child)
     //  (if not found, it's the last bucket, then returns `formattedAggs` itself)
     const nextAggId = Object.keys(formattedAggs).find(k => !!formattedAggs[k].buckets);
-    if(!nextAggId) return formattedAggs;
+    if (!nextAggId) return formattedAggs;
     // Calls itself recursively for every bucket
     const newBuckets = formattedAggs[nextAggId].buckets.map(b => findComparingAgg(b, comparingAggId, metricsAggsIds, isPercentage));
     return {

--- a/public/response_handlers/lib/date_histogram_handler.js
+++ b/public/response_handlers/lib/date_histogram_handler.js
@@ -74,7 +74,7 @@ function getComparingFromDateHistogram(bucket, comparingBucket, comparingAggId) 
   // Finds next bucket child (looks for buckets array inside every child)
   //  (if not found, it's the last bucket, then returns `formattedBucket` itself)
   const nextAggId = Object.keys(formattedBucket).find(k => !!formattedBucket[k].buckets && k !== comparingAggId);
-  if(!nextAggId) return formattedBucket;
+  if (!nextAggId) return formattedBucket;
   // Calls itself recursively for every bucket
   const newBuckets = formattedBucket[nextAggId].buckets.map(subBucket => {
     // Gets next level from comparingBucket


### PR DESCRIPTION
Adding support for comparing aggregation when `Calculate metrics for every bucket/level` option is checked:
![image](https://user-images.githubusercontent.com/16384428/43972485-e9b44dc4-9caa-11e8-8700-7c8e2a6e8770.png)

Main changes:
- [x] `AggConfigs.toDsl` decorator added to request
- [x] `/response_handlers` recursive functions from both `comparing` and `date_histogram_handler` modules changed